### PR TITLE
Cleanup - Trim Trailing Space

### DIFF
--- a/2.7/descriptions.nsh
+++ b/2.7/descriptions.nsh
@@ -1,29 +1,29 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com
 ; =================================================================
 
-; This file keeps generic module descriptions. 
+; This file keeps generic module descriptions.
 ; Don't use any version numbers here as it is shared between versions.
 
 LangString DESC_PYTHON_CORE ${LANG_ENGLISH} "Installs Python core engine. This component is required and can not be deselected."

--- a/2.7/modules.bat
+++ b/2.7/modules.bat
@@ -1,22 +1,22 @@
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: The MIT License (MIT)
 :: Copyright (c) 2007 Perica Zivkovic
- 
-:: Permission is hereby granted, free of charge, to any person obtaining a 
-:: copy of this software and associated documentation files (the "Software"), 
-:: to deal in the Software without restriction, including without limitation 
-:: the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-:: and/or sell copies of the Software, and to permit persons to whom the 
+
+:: Permission is hereby granted, free of charge, to any person obtaining a
+:: copy of this software and associated documentation files (the "Software"),
+:: to deal in the Software without restriction, including without limitation
+:: the rights to use, copy, modify, merge, publish, distribute, sublicense,
+:: and/or sell copies of the Software, and to permit persons to whom the
 :: Software is furnished to do so, subject to the following conditions:
- 
-:: The above copyright notice and this permission notice shall be included 
+
+:: The above copyright notice and this permission notice shall be included
 :: in all copies or substantial portions of the Software.
- 
-:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+
+:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 :: CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 :: http://PortablePython.com
@@ -26,7 +26,7 @@
 set COMMON=.\..\common.bat
 
 call :UnpackPython
-call :UnpackPyScripter 
+call :UnpackPyScripter
 call :UnpackPyCharm
 call :UnpackNumPy
 call :UnpackSciPy
@@ -119,7 +119,7 @@ endlocal&goto :EOF
 :UnpackPyScripter
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts pyScripter 
+:: Func: Downloads and extracts pyScripter
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
@@ -127,7 +127,7 @@ setlocal ENABLEEXTENSIONS
 :: Download PyScripter
 call COMMON :DownloadFile %PY_SCRIPTER_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PY_SCRIPTER_FILE% SHA1 %PY_SCRIPTER_SHA1%
 
 :: Unpack files
@@ -168,15 +168,15 @@ endlocal&goto :EOF
 :UnpackNumPy
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts numpy 
+:: Func: Downloads and extracts numpy
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %NUMPY_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %NUMPY_FILE% MD5 %NUMPY_ZIP_MD5%
 
 :: Unpack files
@@ -194,15 +194,15 @@ endlocal&goto :EOF
 :UnpackSciPy
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts scipy 
+:: Func: Downloads and extracts scipy
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %SCIPY_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %SCIPY_FILE% MD5 %SCIPY_ZIP_MD5%
 
 :: Unpack files
@@ -220,15 +220,15 @@ endlocal&goto :EOF
 :UnpackPyWin32
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts pywin32 
+:: Func: Downloads and extracts pywin32
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PYWIN32_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PYWIN32_FILE% MD5 %PYWIN32_MD5%
 
 :: Unpack files
@@ -253,17 +253,17 @@ endlocal&goto :EOF
 :UnpackNetworkX
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts networkx 
+:: Func: Downloads and extracts networkx
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %NETWORKX_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %NETWORKX_FILE% MD5 %NETWORKX_MD5%
-	
+
 :: Unpack files
 call COMMON :LogMessage "Extracting networkx files"
 tools\uniextract16\UniExtract.exe "%BIN_FOLDER%\%NETWORKX_FILE%" %UNPACK_FOLDER%\networkx\
@@ -278,15 +278,15 @@ endlocal&goto :EOF
 :UnpackDjango
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts django  
+:: Func: Downloads and extracts django
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %DJANGO_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %DJANGO_FILE% MD5 %DJANGO_MD5%
 
 :: Unpack files
@@ -304,12 +304,12 @@ endlocal&goto :EOF
 :UnpackPIL
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts PIL  
+:: Func: Downloads and extracts PIL
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PIL_DOWNLOAD%
 
 :: Unpack files
@@ -326,15 +326,15 @@ endlocal&goto :EOF
 :UnpackPy2Exe
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts Py2Exe  
+:: Func: Downloads and extracts Py2Exe
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PY2EXE_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PY2EXE_FILE% MD5 %PY2EXE_MD5%
 
 :: Unpack files
@@ -351,15 +351,15 @@ endlocal&goto :EOF
 :UnpackWxPython
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts WxPython  
+:: Func: Downloads and extracts WxPython
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %WXPYTHON_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %WXPYTHON_FILE% MD5 %WXPYTHON_MD5%
 
 :: Unpack files
@@ -381,15 +381,15 @@ endlocal&goto :EOF
 :UnpackMatplotlib
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts Matplotlib  
+:: Func: Downloads and extracts Matplotlib
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %MATPLOTLIB_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %MATPLOTLIB_FILE% MD5 %MATPLOTLIB_MD5%
 
 :: Unpack files
@@ -406,15 +406,15 @@ endlocal&goto :EOF
 :UnpackDateutil
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts Dateutil   
+:: Func: Downloads and extracts Dateutil
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %DATEUTIL_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %DATEUTIL_FILE% MD5 %DATEUTIL_MD5%
 
 :: Unpack files
@@ -432,15 +432,15 @@ endlocal&goto :EOF
 :UnpackPyParsing
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts pyparsing   
+:: Func: Downloads and extracts pyparsing
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PYPARSING_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PYPARSING_FILE% MD5 %PYPARSING_MD5%
 
 :: Unpack files
@@ -457,12 +457,12 @@ endlocal&goto :EOF
 :UnpackLXML
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts LXML  
+:: Func: Downloads and extracts LXML
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %LXML_DOWNLOAD%
 
 :: Verify
@@ -482,17 +482,17 @@ endlocal&goto :EOF
 :UnpackPySerial
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts PySerial 
+:: Func: Downloads and extracts PySerial
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PY_SERIAL_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PY_SERIAL_FILE% MD5 %PY_SERIAL_MD5%
-	
+
 :: Unpack files
 call COMMON :LogMessage "Extracting PySerial files"
 tools\uniextract16\UniExtract.exe "%BIN_FOLDER%\%PY_SERIAL_FILE%" %UNPACK_FOLDER%\pyserial\
@@ -515,9 +515,9 @@ setlocal ENABLEEXTENSIONS
 :: Download
 call COMMON :DownloadFile %PYODBC_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PYODBC_FILE% SHA1 %PYODBC_SHA1%
-	
+
 :: Unpack files
 call COMMON :LogMessage "Extracting PyODBC files"
 tools\uniextract16\UniExtract.exe "%BIN_FOLDER%\%PYODBC_FILE%" %UNPACK_FOLDER%\pyodbc\
@@ -537,7 +537,7 @@ endlocal&goto :EOF
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PYGAME_DOWNLOAD%
 
 :: Unpack files
@@ -562,7 +562,7 @@ endlocal&goto :EOF
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PYGTK_DOWNLOAD%
 
 :: Unpack files
@@ -600,10 +600,10 @@ endlocal&goto :EOF
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PYQT_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PYQT_FILE% MD5 %PYQT_MD5%
 
 :: Unpack files
@@ -648,15 +648,15 @@ endlocal&goto :EOF
 :UnpackIPython
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts IPython  
+:: Func: Downloads and extracts IPython
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %IPYTHON_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %IPYTHON_FILE% MD5 %IPYTHON_MD5%
 
 :: Unpack files
@@ -693,7 +693,7 @@ endlocal&goto :EOF
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PANDAS_DOWNLOAD%
 
 :: Unpack files
@@ -710,15 +710,15 @@ endlocal&goto :EOF
 :UnpackSix
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts six   
+:: Func: Downloads and extracts six
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %SIX_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %SIX_FILE% MD5 %SIX_MD5%
 
 :: Unpack files
@@ -736,15 +736,15 @@ endlocal&goto :EOF
 :UnpackXLrd
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts xlrd   
+:: Func: Downloads and extracts xlrd
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %XLRD_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %XLRD_FILE% MD5 %XLRD_MD5%
 
 :: Unpack files
@@ -762,15 +762,15 @@ endlocal&goto :EOF
 :UnpackXLwt
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts xlwt   
+:: Func: Downloads and extracts xlwt
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %XLWT_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %XLWT_FILE% MD5 %XLWT_MD5%
 
 :: Unpack files
@@ -787,15 +787,15 @@ endlocal&goto :EOF
 :UnpackXLUtils
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts xlutils   
+:: Func: Downloads and extracts xlutils
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %XLUTILS_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %XLUTILS_FILE% MD5 %XLUTILS_MD5%
 
 :: Unpack files
@@ -812,15 +812,15 @@ endlocal&goto :EOF
 :UnpackOpenPyXL
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts openpyxl   
+:: Func: Downloads and extracts openpyxl
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %OPENPYXL_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %OPENPYXL_FILE% MD5 %OPENPYXL_MD5%
 
 :: Unpack files
@@ -845,7 +845,7 @@ setlocal ENABLEEXTENSIONS
 :: Download PyCharm
 call COMMON :DownloadFile %PYCHARM_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PYCHARM_FILE% MD5 %PYCHARM_MD5%
 
 :: Unpack files
@@ -874,7 +874,7 @@ set new=%PY_VERSION%
 for /f "tokens=* delims=¶" %%i in ( '"type %filein%"') do (
 	set str=%%i
 	set str=!str:%old%=%new%!
-	echo !str! >> %fileout%	
+	echo !str! >> %fileout%
 )
 del %filein%
 

--- a/2.7/modules.nsh
+++ b/2.7/modules.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com
@@ -133,22 +133,22 @@ SectionGroup "Modules"
 		SectionIn 1
 		SetOutPath "$INSTDIR\App\Lib\site-packages\"
 		File /r "${SOURCESFOLDER}\pandas\PLATLIB\*.*"
-	SectionEnd 
+	SectionEnd
 	Section "Dateutil 2.2" MODULE_DATEUTIL
 		SectionIn 1
 		SetOutPath "$INSTDIR\App\Lib\site-packages\dateutil\"
 		File /r "${SOURCESFOLDER}\dateutil\python-dateutil-2.2\dateutil\*.*"
-	SectionEnd 
+	SectionEnd
 	Section "PyParsing 2.0.1" MODULE_PYPARSING
 		SectionIn 1
 		SetOutPath "$INSTDIR\App\Lib\site-packages\"
 		File /r "${SOURCESFOLDER}\pyparsing\PURELIB\*.*"
-	SectionEnd 
+	SectionEnd
 	Section "Six 1.6.1" MODULE_SIX
 		SectionIn 1
 		SetOutPath "$INSTDIR\App\Lib\site-packages\"
 		File "${SOURCESFOLDER}\SIX\six-1.6.1\six.py"
-	SectionEnd 
+	SectionEnd
 	Section "XLUtils 1.7.0" MODULE_XLUTILS
 		SectionIn 1
 		SetOutPath "$INSTDIR\App\Lib\site-packages\xlutils\"
@@ -184,7 +184,7 @@ SectionGroup "Code editors"
 		SetOutPath "$INSTDIR"
 		File /r "${SOURCESFOLDER}\PyCharm\*.*"
 		File "${SOURCESFOLDER}\PyCharm-Portable.exe"
-	SectionEnd	
+	SectionEnd
 SectionGroupEnd
 
 ; Section dependencies
@@ -203,5 +203,5 @@ Function .onSelChange
 	${EndIf}
 	${Unless} ${SectionIsSelected} ${MODULE_XLWT}
         !insertmacro UnselectSection ${MODULE_XLUTILS}
-	${EndIf}		
+	${EndIf}
 FunctionEnd

--- a/2.7/settings.bat
+++ b/2.7/settings.bat
@@ -1,22 +1,22 @@
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: The MIT License (MIT)
 :: Copyright (c) 2007 Perica Zivkovic
- 
-:: Permission is hereby granted, free of charge, to any person obtaining a 
-:: copy of this software and associated documentation files (the "Software"), 
-:: to deal in the Software without restriction, including without limitation 
-:: the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-:: and/or sell copies of the Software, and to permit persons to whom the 
+
+:: Permission is hereby granted, free of charge, to any person obtaining a
+:: copy of this software and associated documentation files (the "Software"),
+:: to deal in the Software without restriction, including without limitation
+:: the rights to use, copy, modify, merge, publish, distribute, sublicense,
+:: and/or sell copies of the Software, and to permit persons to whom the
 :: Software is furnished to do so, subject to the following conditions:
- 
-:: The above copyright notice and this permission notice shall be included 
+
+:: The above copyright notice and this permission notice shall be included
 :: in all copies or substantial portions of the Software.
- 
-:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+
+:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 :: CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 :: http://PortablePython.com
@@ -48,7 +48,7 @@ set NUMPY_ZIP_MD5=47dcbfaba32a64f1e30927c219853fc1
 set SCIPY_DOWNLOAD="http://sourceforge.net/projects/scipy/files/scipy/0.13.3/scipy-0.13.3-win32-superpack-python2.7.exe"
 set SCIPY_FILE=scipy-0.13.3-win32-superpack-python2.7.exe
 set SCIPY_FILE_NOSSE=scipy-0.13.3-nosse.exe
-set SCIPY_ZIP_MD5=ab43e3022aa642bef49a1f92516a6fdf  
+set SCIPY_ZIP_MD5=ab43e3022aa642bef49a1f92516a6fdf
 
 set PYWIN32_DOWNLOAD="http://sourceforge.net/projects/pywin32/files/pywin32/Build 218/pywin32-218.win32-py2.7.exe"
 set PYWIN32_FILE=pywin32-218.win32-py2.7.exe
@@ -90,14 +90,14 @@ set PYPARSING_MD5=e312e220208383c0b87f3c36996cf47a
 set LXML_DOWNLOAD="https://pypi.python.org/packages/2.7/l/lxml/lxml-3.3.4.win32-py2.7.exe"
 set LXML_FILE=lxml-3.3.4.win32-py2.7.exe
 set LXML_MD5=55384beefb503549675f752697c2095f
-	
+
 set PY_SERIAL_DOWNLOAD="http://sourceforge.net/projects/pyserial/files/pyserial/2.7/pyserial-2.7.win32.exe"
 set PY_SERIAL_FILE=pyserial-2.7.win32.exe
 set PY_SERIAL_MD5=21555387937eeb79126cde25abee4b35
 
 set PYODBC_DOWNLOAD="http://pyodbc.googlecode.com/files/pyodbc-3.0.7.win32-py2.7.exe"
 set PYODBC_FILE=pyodbc-3.0.7.win32-py2.7.exe
-set PYODBC_SHA1=e1992fe4d4983f16e33913e8162f89f50fcde2b0 
+set PYODBC_SHA1=e1992fe4d4983f16e33913e8162f89f50fcde2b0
 
 set PYGAME_DOWNLOAD="http://pygame.org/ftp/pygame-1.9.1.win32-py2.7.msi"
 set PYGAME_FILE=pygame-1.9.1.win32-py2.7.msi

--- a/2.7/test_imports.py
+++ b/2.7/test_imports.py
@@ -8,7 +8,7 @@ class TestCoreSystem(unittest.TestCase):
 
 	def test_setuptools(self):
 		import setuptools
-		self.assertEqual(setuptools.__version__, "0.6c11")		
+		self.assertEqual(setuptools.__version__, "0.6c11")
 
 class TestModuleImports(unittest.TestCase):
 	"""Simple set of tests for package imports in case of full installation"""

--- a/3.2/descriptions.nsh
+++ b/3.2/descriptions.nsh
@@ -1,29 +1,29 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com
 ; =================================================================
 
-; This file keeps generic mofule descriptions. 
+; This file keeps generic mofule descriptions.
 ; Don't use any version numbers here as it is shared between versions.
 
 LangString DESC_PYTHON_CORE ${LANG_ENGLISH} "Installs Python core engine. This component is required and can not be deselected."

--- a/3.2/modules.bat
+++ b/3.2/modules.bat
@@ -1,29 +1,29 @@
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: The MIT License (MIT)
 :: Copyright (c) 2007 Perica Zivkovic
- 
-:: Permission is hereby granted, free of charge, to any person obtaining a 
-:: copy of this software and associated documentation files (the "Software"), 
-:: to deal in the Software without restriction, including without limitation 
-:: the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-:: and/or sell copies of the Software, and to permit persons to whom the 
+
+:: Permission is hereby granted, free of charge, to any person obtaining a
+:: copy of this software and associated documentation files (the "Software"),
+:: to deal in the Software without restriction, including without limitation
+:: the rights to use, copy, modify, merge, publish, distribute, sublicense,
+:: and/or sell copies of the Software, and to permit persons to whom the
 :: Software is furnished to do so, subject to the following conditions:
- 
-:: The above copyright notice and this permission notice shall be included 
+
+:: The above copyright notice and this permission notice shall be included
 :: in all copies or substantial portions of the Software.
- 
-:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+
+:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 :: CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 :: http://PortablePython.com
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :: Include common functions
-set COMMON=.\..\common.bat	
+set COMMON=.\..\common.bat
 
 call :UnpackPython
 call :UnpackPyScripter
@@ -52,7 +52,7 @@ goto:EOF
 setlocal ENABLEEXTENSIONS
 
 :: Download python
-call COMMON :DownloadFile %PY_MSI_DOWNLOAD% 
+call COMMON :DownloadFile %PY_MSI_DOWNLOAD%
 
 :: Verify python core
 call COMMON :VerifyFile %PY_MSI_FILE% MD5 %PY_MSI_MD5%
@@ -64,7 +64,7 @@ msiexec /quiet /a "%BIN_FOLDER%\%PY_MSI_FILE%" TARGETDIR="%UNPACK_FOLDER%\python
 :: Unpack MSCRT patch
 call COMMON :LogMessage "Extracting MSCRT patch"
 tools\uniextract16\UniExtract.exe patches\Microsoft.VC90.CRT.PPpatch %UNPACK_FOLDER%\python-core\App >NUL
-	
+
 :: Download distribute
 call COMMON :DownloadFile %PY_DISTRIBUTE_DOWNLOAD%
 :: Verify distribute
@@ -106,7 +106,7 @@ endlocal&goto :EOF
 :UnpackPyScripter
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts pyScripter 
+:: Func: Downloads and extracts pyScripter
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
@@ -114,7 +114,7 @@ setlocal ENABLEEXTENSIONS
 :: Download PyScripter
 call COMMON :DownloadFile %PY_SCRIPTER_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PY_SCRIPTER_FILE% SHA1 %PY_SCRIPTER_SHA1%
 
 :: Unpack files
@@ -155,15 +155,15 @@ endlocal&goto :EOF
 :UnpackNumPy
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts numpy 
+:: Func: Downloads and extracts numpy
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %NUMPY_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %NUMPY_FILE% MD5 %NUMPY_ZIP_MD5%
 
 :: Unpack files
@@ -181,15 +181,15 @@ endlocal&goto :EOF
 :UnpackSciPy
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts scipy 
+:: Func: Downloads and extracts scipy
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %SCIPY_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %SCIPY_FILE% MD5 %SCIPY_ZIP_MD5%
 
 :: Unpack files
@@ -207,25 +207,25 @@ endlocal&goto :EOF
 :UnpackPyWin32
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts pywin32 
+:: Func: Downloads and extracts pywin32
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PYWIN32_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PYWIN32_FILE% MD5 %PYWIN32_MD5%
 
 :: Unpack files
 call COMMON :LogMessage "Extracting PyWin32 files"
-mkdir %UNPACK_FOLDER%\pywin32-temp\ 
+mkdir %UNPACK_FOLDER%\pywin32-temp\
 tools\uniextract16\bin\7z.exe x "%BIN_FOLDER%\%PYWIN32_FILE%" -o%UNPACK_FOLDER%\pywin32-temp\ >NUL
 
-mkdir %UNPACK_FOLDER%\pywin32\ 
-mkdir %UNPACK_FOLDER%\pywin32\Lib 
-mkdir %UNPACK_FOLDER%\pywin32\Lib\site-packages\ 
+mkdir %UNPACK_FOLDER%\pywin32\
+mkdir %UNPACK_FOLDER%\pywin32\Lib
+mkdir %UNPACK_FOLDER%\pywin32\Lib\site-packages\
 
 xcopy /QEY %UNPACK_FOLDER%\pywin32-temp\PLATLIB\pywin32_system32\*.* %UNPACK_FOLDER%\pywin32\ >NUL
 rmdir /S /Q %UNPACK_FOLDER%\pywin32-temp\PLATLIB\pywin32_system32 >NUL
@@ -241,17 +241,17 @@ endlocal&goto :EOF
 :UnpackNetworkX
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts networkx 
+:: Func: Downloads and extracts networkx
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %NETWORKX_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %NETWORKX_FILE% MD5 %NETWORKX_MD5% >NUL
-	
+
 :: Unpack files
 call COMMON :LogMessage "Extracting networkx files"
 tools\uniextract16\UniExtract.exe "%BIN_FOLDER%\%NETWORKX_FILE%" %UNPACK_FOLDER%\networkx\ >NUL
@@ -266,15 +266,15 @@ endlocal&goto :EOF
 :UnpackMatplotlib
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts Matplotlib  
+:: Func: Downloads and extracts Matplotlib
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %MATPLOTLIB_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %MATPLOTLIB_FILE% MD5 %MATPLOTLIB_MD5%
 
 :: Unpack files
@@ -291,12 +291,12 @@ endlocal&goto :EOF
 :UnpackLXML
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts LXML  
+:: Func: Downloads and extracts LXML
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %LXML_DOWNLOAD%
 
 :: Unpack files
@@ -313,17 +313,17 @@ endlocal&goto :EOF
 :UnpackPySerial
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts PySerial 
+:: Func: Downloads and extracts PySerial
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PY_SERIAL_DOWNLOAD% %PY_SERIAL_FILE%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PY_SERIAL_FILE% MD5 %PY_SERIAL_MD5%
-        
+
 :: Unpack files
 call COMMON :LogMessage "Extracting PySerial files"
 tools\uniextract16\UniExtract.exe "%BIN_FOLDER%\%PY_SERIAL_FILE%" %UNPACK_FOLDER%\pyserial\ >NUL
@@ -346,9 +346,9 @@ setlocal ENABLEEXTENSIONS
 :: Download
 call COMMON :DownloadFile %PYODBC_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PYODBC_FILE% SHA1 %PYODBC_SHA1%
-	
+
 :: Unpack files
 call COMMON :LogMessage "Extracting PyODBC files"
 tools\uniextract16\UniExtract.exe "%BIN_FOLDER%\%PYODBC_FILE%" %UNPACK_FOLDER%\pyodbc\ >NUL
@@ -368,10 +368,10 @@ endlocal&goto :EOF
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PYQT_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PYQT_FILE% MD5 %PYQT_MD5%
 
 :: Unpack files
@@ -414,15 +414,15 @@ endlocal&goto :EOF
 :UnpackIPython
 ::
 :: By:   Perica Zivkovic
-:: Func: Downloads and extracts IPython  
+:: Func: Downloads and extracts IPython
 :: Args: none
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %IPYTHON_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %IPYTHON_FILE% MD5 %IPYTHON_MD5%
 
 :: Unpack files
@@ -459,7 +459,7 @@ endlocal&goto :EOF
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 setlocal ENABLEEXTENSIONS
 
-:: Download 
+:: Download
 call COMMON :DownloadFile %PANDAS_DOWNLOAD%
 
 :: Unpack files
@@ -483,7 +483,7 @@ setlocal ENABLEEXTENSIONS
 :: Download PyCharm
 call COMMON :DownloadFile %PYCHARM_DOWNLOAD%
 
-:: Verify 
+:: Verify
 call COMMON :VerifyFile %PYCHARM_FILE% MD5 %PYCHARM_MD5%
 
 :: Unpack files
@@ -512,7 +512,7 @@ set new=%PY_VERSION%
 for /f "tokens=* delims=¶" %%i in ( '"type %filein%"') do (
 	set str=%%i
 	set str=!str:%old%=%new%!
-	echo !str! >> %fileout%	
+	echo !str! >> %fileout%
 )
 del %filein%
 

--- a/3.2/modules.nsh
+++ b/3.2/modules.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com
@@ -64,7 +64,7 @@ SectionGroup "Modules"
 		SectionIn 1
 		SetOutPath "$INSTDIR\App\Lib\site-packages\"
 		File /r "${SOURCESFOLDER}\lxml\PLATLIB\*.*"
-	SectionEnd	
+	SectionEnd
 	Section "PySerial 2.5" MODULE_PY_SERIAL
 		SectionIn 1
 		SetOutPath "$INSTDIR\App\Lib\site-packages\"
@@ -95,7 +95,7 @@ SectionGroup "Modules"
 		SectionIn 1
 		SetOutPath "$INSTDIR\App\Lib\site-packages\"
 		File /r "${SOURCESFOLDER}\pandas\PLATLIB\*.*"
-	SectionEnd 
+	SectionEnd
 SectionGroupEnd
 
 SectionGroup "Code editors"
@@ -110,7 +110,7 @@ SectionGroup "Code editors"
 		SetOutPath "$INSTDIR"
 		File /r "${SOURCESFOLDER}\PyCharm\*.*"
 		File "${SOURCESFOLDER}\PyCharm-Portable.exe"
-	SectionEnd	
+	SectionEnd
 SectionGroupEnd
 
 

--- a/3.2/settings.bat
+++ b/3.2/settings.bat
@@ -1,22 +1,22 @@
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: The MIT License (MIT)
 :: Copyright (c) 2007 Perica Zivkovic
- 
-:: Permission is hereby granted, free of charge, to any person obtaining a 
-:: copy of this software and associated documentation files (the "Software"), 
-:: to deal in the Software without restriction, including without limitation 
-:: the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-:: and/or sell copies of the Software, and to permit persons to whom the 
+
+:: Permission is hereby granted, free of charge, to any person obtaining a
+:: copy of this software and associated documentation files (the "Software"),
+:: to deal in the Software without restriction, including without limitation
+:: the rights to use, copy, modify, merge, publish, distribute, sublicense,
+:: and/or sell copies of the Software, and to permit persons to whom the
 :: Software is furnished to do so, subject to the following conditions:
- 
-:: The above copyright notice and this permission notice shall be included 
+
+:: The above copyright notice and this permission notice shall be included
 :: in all copies or substantial portions of the Software.
- 
-:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+
+:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 :: CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 :: http://PortablePython.com
@@ -49,7 +49,7 @@ set NUMPY_ZIP_MD5=bb0d30de007d649757a2d6d2e1c59c9a
 set SCIPY_DOWNLOAD="http://sourceforge.net/projects/scipy/files/scipy/0.12.0/scipy-0.12.0-win32-superpack-python3.2.exe"
 set SCIPY_FILE=scipy-0.12.0-win32-superpack-python3.2.exe
 set SCIPY_FILE_NOSSE=scipy-0.12.0-nosse.exe
-set SCIPY_ZIP_MD5=391b306093c43f58d6588cee76bf0c10  
+set SCIPY_ZIP_MD5=391b306093c43f58d6588cee76bf0c10
 
 set PYWIN32_DOWNLOAD="http://sourceforge.net/projects/pywin32/files/pywin32/Build 218/pywin32-218.win32-py3.2.exe"
 set PYWIN32_FILE=pywin32-218.win32-py3.2.exe

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,10 +1,10 @@
 The MIT License (MIT)
 Copyright (c) 2007 Perica Zivkovic
- 
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- 
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 http://PortablePython.com

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ==============
 
 #### What is Portable Python?
-Portable Python is a [Python® programming language](http://Python.org/ "Python® programming language") pre-configured to run directly from any USB storage device, local or network location enabling you to have, at any time, a portable programming environment. 
+Portable Python is a [Python® programming language](http://Python.org/ "Python® programming language") pre-configured to run directly from any USB storage device, local or network location enabling you to have, at any time, a portable programming environment.
 
 #### Licensing
 Portable Python build scripts are licensed under MIT license, other third party tools and packages are licensed by their respecitive projects/owners.
@@ -10,7 +10,7 @@ Portable Python build scripts are licensed under MIT license, other third party 
 #### Usage
 Portable Python build scripts can be invoked from any MS Windows command prompt by using `build` command and specifying version to be created, e.g.:
 
-`build 2.7` 
+`build 2.7`
 
 will download all components needed for building Portable Python based on the Python 2.7, unpack all packages to current user temp folder and create final installer.
 

--- a/build.bat
+++ b/build.bat
@@ -1,22 +1,22 @@
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: The MIT License (MIT)
 :: Copyright (c) 2007 Perica Zivkovic
- 
-:: Permission is hereby granted, free of charge, to any person obtaining a 
-:: copy of this software and associated documentation files (the "Software"), 
-:: to deal in the Software without restriction, including without limitation 
-:: the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-:: and/or sell copies of the Software, and to permit persons to whom the 
+
+:: Permission is hereby granted, free of charge, to any person obtaining a
+:: copy of this software and associated documentation files (the "Software"),
+:: to deal in the Software without restriction, including without limitation
+:: the rights to use, copy, modify, merge, publish, distribute, sublicense,
+:: and/or sell copies of the Software, and to permit persons to whom the
 :: Software is furnished to do so, subject to the following conditions:
- 
-:: The above copyright notice and this permission notice shall be included 
+
+:: The above copyright notice and this permission notice shall be included
 :: in all copies or substantial portions of the Software.
- 
-:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+
+:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 :: CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 :: http://PortablePython.com
@@ -28,7 +28,7 @@
 set COMMON=.\..\common.bat
 
 if "" == "%1" (
-		call COMMON :EchoUsage 
+		call COMMON :EchoUsage
 		goto:eof
 	)
 
@@ -36,12 +36,12 @@ set USE_CACHE=TRUE
 if "--clean" == "%2" (
 		set USE_CACHE=FALSE
 	)
-	
+
 call COMMON :LogMessage
 call COMMON :LogMessage "Portable Python build script started :: %date% %time%"
 call COMMON :LogMessage
 call COMMON :LogMessage "Building distribution based on Python %1"
-	
+
 :: Check can we find config dir
 if not exist %1 (
 		call COMMON :LogMessage "ERROR: Config folder not found for this version !! Aborting..."
@@ -49,7 +49,7 @@ if not exist %1 (
 	)
 
 :: Load variables for specified version
-call .\%1\settings.bat 
+call .\%1\settings.bat
 
 set TEMP_FOLDER=%TEMP%PortablePython.v.%PY_VERSION%.%PP_VERSION%.Build
 set BIN_FOLDER=%TEMP_FOLDER%\binaries
@@ -66,12 +66,12 @@ if exist %TEMP_FOLDER%\Fix.log (
 	)
 
 :: Prepare temporary folder
-if not exist %TEMP_FOLDER% ( 
+if not exist %TEMP_FOLDER% (
 		mkdir %TEMP_FOLDER%
 		:: Create working folder structure
 		mkdir %BIN_FOLDER%
 		mkdir %UNPACK_FOLDER%
-		mkdir %OUTPUT_FOLDER%		
+		mkdir %OUTPUT_FOLDER%
 	) else (
 		if not %USE_CACHE% == TRUE (
 			call COMMON :LogMessage "Not using cache - deleting all temp files"
@@ -89,14 +89,14 @@ if not exist %TEMP_FOLDER% (
 			mkdir %OUTPUT_FOLDER%
 		)
 	)
-	
+
 :: Extract modules
-call .\%1\modules.bat 
+call .\%1\modules.bat
 
 :: Build installer
-call COMMON :LogMessage 
+call COMMON :LogMessage
 call COMMON :LogMessage "Building Portable Python %PY_VERSION%.%PP_VERSION% installer ..."
 tools\nsis\makensis /V0 /DPY_VERSION=%1 /DPP_VERSION=%PP_VERSION% /DOUTPUT_FOLDER="%OUTPUT_FOLDER%" /DSOURCES_FOLDER="%UNPACK_FOLDER%" main.nsi
-call COMMON :LogMessage 
+call COMMON :LogMessage
 call COMMON :LogMessage "Portable Python build script completed at :: %date% %time%"
 call COMMON :LogMessage "Installer ready at: %OUTPUT_FOLDER%"

--- a/common.bat
+++ b/common.bat
@@ -1,22 +1,22 @@
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: The MIT License (MIT)
 :: Copyright (c) 2007 Perica Zivkovic
- 
-:: Permission is hereby granted, free of charge, to any person obtaining a 
-:: copy of this software and associated documentation files (the "Software"), 
-:: to deal in the Software without restriction, including without limitation 
-:: the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-:: and/or sell copies of the Software, and to permit persons to whom the 
+
+:: Permission is hereby granted, free of charge, to any person obtaining a
+:: copy of this software and associated documentation files (the "Software"),
+:: to deal in the Software without restriction, including without limitation
+:: the rights to use, copy, modify, merge, publish, distribute, sublicense,
+:: and/or sell copies of the Software, and to permit persons to whom the
 :: Software is furnished to do so, subject to the following conditions:
- 
-:: The above copyright notice and this permission notice shall be included 
+
+:: The above copyright notice and this permission notice shall be included
 :: in all copies or substantial portions of the Software.
- 
-:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+
+:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+:: OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+:: WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 :: CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 :: http://PortablePython.com
@@ -71,7 +71,7 @@ for /F "tokens=1* delims=/ " %%A in ( "%var1%" ) do (
 
 for /F "tokens=%i% delims=/ " %%G in ( "%var2%" ) do set last=%%G
 
-call :LogMessage 
+call :LogMessage
 call :LogMessage "Downloading: %last%"
 >> %TEMP_FOLDER%\Build.log echo %last%
 
@@ -124,11 +124,11 @@ endlocal&goto :EOF
 setlocal ENABLEEXTENSIONS
 echo ::
 echo ::  Usage: build version [--clean]
-echo ::         - version: version of the python core to use for build in 
+echo ::         - version: version of the python core to use for build in
 echo ::                    major.minor format, eg. 3.2 will build new
 echo ::                    Portable Python distribution based on Python 3.2
 echo ::
-echo ::			--clean will force clean build - remove all cached binaries 
+echo ::			--clean will force clean build - remove all cached binaries
 echo ::
 endlocal&goto :EOF
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/main.nsi
+++ b/main.nsi
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com
@@ -81,7 +81,7 @@ SetDatablockOptimize On
 !insertmacro MUI_PAGE_WELCOME
 ; Directory page
 !insertmacro MUI_PAGE_DIRECTORY
-; Components page 
+; Components page
 !insertmacro MUI_PAGE_COMPONENTS
 ; Instfiles page
 !insertmacro MUI_PAGE_INSTFILES

--- a/shortcuts/Glade3.nsh
+++ b/shortcuts/Glade3.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com

--- a/shortcuts/IDLE.nsh
+++ b/shortcuts/IDLE.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com

--- a/shortcuts/IPython.nsh
+++ b/shortcuts/IPython.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com

--- a/shortcuts/PyCharm.nsh
+++ b/shortcuts/PyCharm.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com

--- a/shortcuts/PyScripter.nsh
+++ b/shortcuts/PyScripter.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com

--- a/shortcuts/Python.nsh
+++ b/shortcuts/Python.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com

--- a/shortcuts/PythonW.nsh
+++ b/shortcuts/PythonW.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com

--- a/shortcuts/QtDesigner.nsh
+++ b/shortcuts/QtDesigner.nsh
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com

--- a/shortcuts/shortcut.nsi
+++ b/shortcuts/shortcut.nsi
@@ -1,23 +1,23 @@
 ; =================================================================
 ; The MIT License (MIT)
 ; Copyright (c) 2007 Perica Zivkovic
- 
-; Permission is hereby granted, free of charge, to any person obtaining a copy 
-; of this software and associated documentation files (the "Software"), to deal 
-; in the Software without restriction, including without limitation the rights 
-; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-; copies of the Software, and to permit persons to whom the Software is furnished 
+
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is furnished
 ; to do so, subject to the following conditions:
- 
-; The above copyright notice and this permission notice shall be included in all 
+
+; The above copyright notice and this permission notice shall be included in all
 ; copies or substantial portions of the Software.
- 
-; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+; DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ; OTHER DEALINGS IN THE SOFTWARE.
 
 ; http://PortablePython.com
@@ -118,7 +118,7 @@ Function Launch
 	System::Call 'Kernel32::SetEnvironmentVariable(t "PYTHONPATH",t R0)i' 	; Set PYTHONPATH temporarily
 	System::Call 'Kernel32::SetEnvironmentVariable(t "PATH",t R1)i'			; Set PATH temporarily
 	System::Call 'Kernel32::SetEnvironmentVariable(t "PYTHONSTARTUP",t R2)i'			; Set Python prompt temporarily
-		
+
 	ExecWait "$\"$EXEDIR\${APPDIR}\${APPEXE}$\" ${APPSWITCH} $0" 	; EXEC app with parameters
 FunctionEnd
 


### PR DESCRIPTION
tabs & spaces can cause problems especially in batch files, because the
spaces often are interpreted as part of a path in MSW.
So clean all the dev files.
